### PR TITLE
Use Docsify router when fetching terms from the _glossary.md file

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -18,8 +18,9 @@ export function install (hook, vm) {
         }
 
         if(!window.$docsify.terms){
-          fetch('_glossary.md').then(function(data){
-            data.text().then(function(text){
+          Docsify
+            .get(vm.router.getFile("/_glossary"), false, vm.config.requestHeaders)
+            .then(text => {
               window.$docsify.terms = {};
 
               let lines = text.split('\n');
@@ -34,7 +35,6 @@ export function install (hook, vm) {
               });
 
               addLinks(content,next,window.$docsify.terms);
-            })
           })
         } else{
           addLinks(content,next,window.$docsify.terms);


### PR DESCRIPTION
Just as the title says.
In our use can we wanted to put the `_glossary.md` in a different location.
However, adding an alias to the Docsify config would break the plugin, as it couldn't fetch the terms from the correct location.